### PR TITLE
Bumping innosetup from 6.3.1 to 6.3.2 to address Seek bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,13 @@ RUN wine reg add 'HKEY_CURRENT_USER\Software\Wine' /v ShowDotFiles /d Y \
     && while [ ! -f /home/xclient/.wine/user.reg ]; do sleep 1; done
 
 # Install Inno Setup binaries
-RUN curl -SL "https://files.jrsoftware.org/is/6/innosetup-6.3.1.exe" -o is.exe \
+RUN curl -SL "https://files.jrsoftware.org/is/6/innosetup-6.3.2.exe" -o is.exe \
     && wine-x11-run wine is.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES /DOWNLOADISCRYPT=1 \
     && rm is.exe
 
 # Install unofficial languages
 RUN cd "/home/xclient/.wine/drive_c/Program Files/Inno Setup 6/Languages" \
-    && curl -L "https://api.github.com/repos/jrsoftware/issrc/tarball/is-6_3_1" \
+    && curl -L "https://api.github.com/repos/jrsoftware/issrc/tarball/is-6_3_2" \
     | tar xz --strip-components=4 --wildcards "*/Files/Languages/Unofficial/*.isl"
 
 FROM debian:buster-slim


### PR DESCRIPTION
Updating binaries and language source to use innosetup 6.3.2.

https://github.com/amake/innosetup-docker/issues/18
